### PR TITLE
feat: add post training libs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ pull-requests are very welcomed. __Please do not list any confidential projects!
 | Google Internal | Google External                          | Open Source / Real-World                 |
 | --------------- | ---------------------------------------- | ---------------------------------------- |
 | Pre-training  |  | [transformers](https://github.com/huggingface/transformers), [composer](https://github.com/mosaicml/composer), [ms-swift](https://github.com/modelscope/ms-swift), [unsloth](https://github.com/unslothai/unsloth) |
-| Post-training    |  | [trl](https://github.com/huggingface/trl) |
+| Post-training    |  | [trl](https://github.com/huggingface/trl), [OpenRLHF](https://github.com/OpenRLHF/OpenRLHF), [verl](https://github.com/volcengine/verl),  |
 
 
 ### Inference/Serving stacks


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Added new libraries to the post-training section in the README.

- Enhanced documentation for post-training resources.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add new post-training libraries to README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Added <code>OpenRLHF</code> and <code>verl</code> to the post-training libraries list.<br> <li> Updated the post-training section for better resource coverage.


</details>


  </td>
  <td><a href="https://github.com/lingjiekong/xg2xg-ai/pull/11/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>